### PR TITLE
Disqus appearing on pages + fix

### DIFF
--- a/bootstrap-tumblr-theme.html
+++ b/bootstrap-tumblr-theme.html
@@ -536,7 +536,7 @@
                   
         </div> <!-- .row .post -->
 
-        {block:PermalinkPage} 
+        {block:PermalinkPagination} 
         {block:IfDisqusShortname}
         <div class="row">
           <div class="span10 offset2 comments-container">
@@ -546,7 +546,7 @@
           </div> <!-- .comments-container -->
         </div>
         {/block:IfDisqusShortname}
-        {/block:PermalinkPage} 
+        {/block:PermalinkPagination} 
 
         {block:NoteCount}
         <div class="row">


### PR DESCRIPTION
I noticed that disqus comments were appearing on pages.  I think this is because the Disqus section was wrapped in a "{block:PermalinkPage}" tag rather than a "{block:PermalinkPagination}" tag.  I've made the change on my own copy of the template and it works as expected, with disqus only appearing on posts and not on pages.
